### PR TITLE
chore(ci): upgrade GitHub Actions for Node.js 24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main]
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   test:
     runs-on: ubuntu-latest
@@ -15,10 +18,10 @@ jobs:
         node-version: [25.x]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Setup Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ matrix.node-version }}
           cache: "npm"
@@ -40,10 +43,10 @@ jobs:
     needs: test
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: "25.x"
           cache: "npm"
@@ -60,7 +63,7 @@ jobs:
           PUBLIC_SITE_URL: ${{ secrets.PUBLIC_SITE_URL }}
 
       - name: Upload build artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: dist
           path: dist/

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     branches: [main]
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 permissions:
   contents: read
 
@@ -12,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Dependency Review
         uses: actions/dependency-review-action@v4


### PR DESCRIPTION
## Description

Upgrade GitHub Actions to versions that support Node.js 24, addressing the deprecation of Node.js 20 on GitHub Actions runners (default switch to Node 24 in June 2026).

## Type of Change

<!-- Mark the relevant option with an "x" -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Dependency update

## Related Issues

<!-- Link to related issues using #issue_number -->

Closes #

## Changes Made

<!-- Provide a detailed list of changes -->

- Bump actions/checkout and actions/setup-node to v6
- Bump actions/upload-artifact to v7
- Set FORCE_JAVASCRIPT_ACTIONS_TO_NODE24 for dependency-review

## Testing

<!-- Describe the tests you ran and how to reproduce them -->

- [x] All existing tests pass (`npm test`)
- [x] Linting passes (`npm run lint`)
- [x] Build succeeds (`npm run build`)
- [ ] Tested in development mode
- [ ] Tested in production build
- [ ] Added new tests for new functionality

## Screenshots (if applicable)

<!-- Add screenshots to demonstrate visual changes -->

N/A – CI/workflow changes only.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Additional Notes

<!-- Add any additional notes or context about the PR here -->

`FORCE_JAVASCRIPT_ACTIONS_TO_NODE24` is set so that `actions/dependency-review-action` (still at v4, no v6 release) runs on Node 24 until that action is updated.