### PR TITLE
fix(dark-mode): fix muted text, contact form border and placeholder visibility

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -89,7 +89,7 @@ const getBreadCrumbs = (n) => {
 		Astro.params.uri !== undefined && node && getBreadCrumbs(node) && (
 			<div class="footer-breadcrumbs my-4" transition:animate="fade">
 				<small
-					class="text-[var(--color-gray-600)]"
+					class="text-[var(--color-text-muted)]"
 					set:html={getBreadCrumbs(node)}
 				/>
 			</div>
@@ -98,7 +98,7 @@ const getBreadCrumbs = (n) => {
 	<hr
 		class="footer-separator my-4 border-0 border-t border-[var(--color-border)]"
 	/>
-	<small class="footer-built-with block text-xs text-[var(--color-gray-600)]">
+	<small class="footer-built-with block text-xs text-[var(--color-text-muted)]">
 		built with <a
 			href="https://astro.build/"
 			target="_blank"

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -51,7 +51,7 @@ const showSiteName = !isHome && !isSinglePost;
 	}
 	{
 		showSiteName && showBlogTag && (
-			<p class="header-tagline text-sm text-[var(--color-gray-600)]">blog</p>
+			<p class="header-tagline text-sm text-[var(--color-text-muted)]">blog</p>
 		)
 	}
 

--- a/src/components/PostMeta.astro
+++ b/src/components/PostMeta.astro
@@ -34,7 +34,7 @@ const estimatedReadingTime = (postContent: string) => {
 {
 	post && (
 		<div
-			class={`post-meta flex flex-wrap items-center gap-1.5 text-sm leading-none text-[var(--color-gray-600)] ${centered ? "justify-center" : ""}`}
+			class={`post-meta flex flex-wrap items-center gap-1.5 text-sm leading-none text-[var(--color-text-muted)] ${centered ? "justify-center" : ""}`}
 		>
 			<FontAwesomeIcon
 				icon={faClock}

--- a/src/styles/styles.css
+++ b/src/styles/styles.css
@@ -450,6 +450,7 @@ body:not(.darkmode--activated) .darkmode-background {
 body.darkmode--activated {
 	/* Override the shared color vars used by the layout and Tailwind text utilities */
 	--color-text: var(--color-white);
+	--color-text-muted: var(--color-gray-400);
 	--color-border: var(--color-border-dark);
 	--color-background: var(--color-background-dark);
 
@@ -579,9 +580,14 @@ body.darkmode--activated {
 	color: var(--color-white) !important;
 }
 
+.darkmode--activated .contact-form form input,
+.darkmode--activated .contact-form form textarea {
+	border-color: var(--color-white);
+}
+
 .darkmode--activated .contact-form form input::placeholder,
 .darkmode--activated .contact-form form textarea::placeholder {
-	color: var(--color-black);
+	color: var(--color-white);
 }
 
 .darkmode--activated .contact-form form button[type="submit"] {


### PR DESCRIPTION
## Description

The changes cover three distinct issues:                                                                                                                                                               
- Palette var --color-gray-600 swapped for semantic --color-text-muted in Footer, Header, PostMeta — plus a dark mode override (--color-gray-400) so it adapts
- Contact form inputs/textarea get a white border in dark mode
- Contact form placeholder color corrected from --color-black to --color-white


## Type of Change

<!-- Mark the relevant option with an "x" -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Dependency update

## Related Issues

<!-- Link to related issues using #issue_number -->

Closes #

## Changes Made

<!-- Provide a detailed list of changes -->

## Testing

<!-- Describe the tests you ran and how to reproduce them -->

- [x] All existing tests pass (`npm test`)
- [x] Linting passes (`npm run lint`)
- [x] Build succeeds (`npm run build`)
- [x] Tested in development mode
- [x] Tested in production build
- [ ] Added new tests for new functionality

## Screenshots (if applicable)

<!-- Add screenshots to demonstrate visual changes -->

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Additional Notes

<!-- Add any additional notes or context about the PR here -->
