### PR TITLE
Fix for incomplete multi-character sanitization

### DIFF
--- a/src/components/__tests__/PostCardBasic.test.js
+++ b/src/components/__tests__/PostCardBasic.test.js
@@ -17,7 +17,12 @@ class PostCardMock {
 
 	getExcerpt(maxLength = 150) {
 		// Simplified excerpt logic
-		const text = String(this.post.content).replace(/<[^>]*>/g, "");
+		const text = String(this.post.content)
+			.replace(/&/g, "&amp;")
+			.replace(/</g, "&lt;")
+			.replace(/>/g, "&gt;")
+			.replace(/"/g, "&quot;")
+			.replace(/'/g, "&#39;");
 		return text.length > maxLength
 			? text.substring(0, maxLength) + "..."
 			: text;

--- a/src/components/__tests__/PostCardBasic.test.js
+++ b/src/components/__tests__/PostCardBasic.test.js
@@ -17,12 +17,7 @@ class PostCardMock {
 
 	getExcerpt(maxLength = 150) {
 		// Simplified excerpt logic
-		const text = String(this.post.content)
-			.replace(/&/g, "&amp;")
-			.replace(/</g, "&lt;")
-			.replace(/>/g, "&gt;")
-			.replace(/"/g, "&quot;")
-			.replace(/'/g, "&#39;");
+		const text = String(this.post.content).replace(/<[^>]*>/g, "");
 		return text.length > maxLength
 			? text.substring(0, maxLength) + "..."
 			: text;

--- a/src/components/__tests__/PostCardBasic.test.js
+++ b/src/components/__tests__/PostCardBasic.test.js
@@ -17,7 +17,7 @@ class PostCardMock {
 
 	getExcerpt(maxLength = 150) {
 		// Simplified excerpt logic
-		const text = this.post.content.replace(/<[^>]*>/g, "");
+		const text = String(this.post.content).replace(/[<>]/g, "");
 		return text.length > maxLength
 			? text.substring(0, maxLength) + "..."
 			: text;

--- a/src/components/__tests__/PostCardBasic.test.js
+++ b/src/components/__tests__/PostCardBasic.test.js
@@ -17,7 +17,7 @@ class PostCardMock {
 
 	getExcerpt(maxLength = 150) {
 		// Simplified excerpt logic
-		const text = String(this.post.content).replace(/[<>]/g, "");
+		const text = String(this.post.content).replace(/<[^>]*>/g, "");
 		return text.length > maxLength
 			? text.substring(0, maxLength) + "..."
 			: text;


### PR DESCRIPTION
Potential fix for [https://github.com/mladimatija/wp-graphql-astro/security/code-scanning/3](https://github.com/mladimatija/wp-graphql-astro/security/code-scanning/3)

Best fix: avoid trying to remove full HTML tags with a complex multi-character regex. Instead, neutralize HTML metacharacters (`<` and `>`) so no tag can form, then do truncation. This removes the incomplete multi-character sanitization risk while preserving existing “plain excerpt text” behavior.

In `src/components/__tests__/PostCardBasic.test.js`, update `getExcerpt` at line 20:
- Replace `this.post.content.replace(/<[^>]*>/g, "")`
- With a safer character-level replacement such as `String(this.post.content).replace(/[<>]/g, "")`

This keeps functionality close (excerpt text without HTML tags/angles), avoids dependency changes, and resolves the specific CodeQL finding.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
