### PR TITLE
Fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+  actions: read
+
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 


### PR DESCRIPTION
Potential fix for [https://github.com/mladimatija/wp-graphql-astro/security/code-scanning/1](https://github.com/mladimatija/wp-graphql-astro/security/code-scanning/1)

Add an explicit `permissions` block at the workflow root in `.github/workflows/ci.yml`, directly after the `on:` section (or before `env:`), so it applies to all jobs unless overridden.

Best fix without changing functionality: set minimal required scopes:
- `contents: read` (needed by `actions/checkout`)
- `actions: read` (safe for reading workflow/action metadata)

No write scopes appear required by current steps (`upload-artifact` does not require `contents: write`). This keeps behavior intact while enforcing least privilege.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
